### PR TITLE
Small changes to make it work with docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,47 @@ You need the container name or id of the healthchecks instance. You can get it b
 docker exec -it CONTAINER_NAME healthchecks_create_superuser.sh
 ```
 Follow the assistant that will show up to create a healthchecks superuser.
+
+### Docker-Compose
+Example docker-compose.yml
+```
+version: '3'
+
+services:
+  hc:
+    image: galexrt/healthchecks:latest
+    restart: always
+    ports:
+      - "8000:8000"
+      - "2525:2525"
+    volumes:
+      - HC_Data:/healthchecks
+      - HC_SQLite:/data
+    environment:
+      HC_HOST: "0.0.0.0"
+      HC_SECRET_KEY: "blablabla"
+      HC_ALLOWED_HOSTS: "hc.example.com"
+      HC_DEBUG: "False"
+      HC_DEFAULT_FROM_EMAIL: "noreply@hc.example.com"
+      HC_USE_PAYMENTS: "False"
+      HC_REGISTRATION_OPEN: "False"
+      HC_EMAIL_HOST: ""
+      HC_EMAIL_PORT: "587"
+      HC_EMAIL_HOST_USER: ""
+      HC_EMAIL_HOST_PASSWORD: ""
+      HC_EMAIL_USE_TLS: "True"
+      HC_SITE_ROOT: "https://hc.example.com"
+      HC_SITE_NAME: "Mychecks"
+      HC_MASTER_BADGE_LABEL: "Mychecks"
+      HC_PING_ENDPOINT: "https://hc.example.com/ping/"
+      HC_PING_EMAIL_DOMAIN: "hc.example.com"
+      HC_TWILIO_ACCOUNT: "None"
+      HC_TWILIO_AUTH: "None"
+      HC_TWILIO_FROM: "None"
+      HC_PD_VENDOR_KEY: "None"
+      HC_TRELLO_APP_KEY: "None"
+      
+volumes:
+  HC_SQLite:
+  HC_Data:
+```

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ services:
     environment:
       HC_HOST: "0.0.0.0"
       HC_SECRET_KEY: "blablabla"
-      HC_ALLOWED_HOSTS: "hc.example.com"
+      HC_ALLOWED_HOSTS: '["*", "myotherhost", "example.com", "hc.example.com"]'
       HC_DEBUG: "False"
       HC_DEFAULT_FROM_EMAIL: "noreply@hc.example.com"
       HC_USE_PAYMENTS: "False"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple to use Docker image for [github.com/healthchecks/healthchecks](https://gi
 
 ## Running the image
 **If you want to add a variable as a setting you have to prefix it with `HC_`.**
-By default Healthchecks uses a SQLite database, located at `/healthchecks/hc.sqlite`.
+By default Healthchecks uses a SQLite database, located at `/data/hc.sqlite`.
 ```
 docker run \
     -d \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,18 +84,8 @@ settingsConfiguration() {
         fi
 
         if [ "$setting_type" = "plain" ]; then
-            if [ "$setting_key" = "ALLOWED_HOSTS" ]; then
-	        if [ "$setting_var" = "*" ]; then
-			echo "ALLOWED_HOSTS = [\"*\"]" >> /healthchecks/hc/local_settings.py
-		else
-			echo "$setting_key = [\"$setting_var\"]" >> /healthchecks/hc/local_settings.py
-		fi
-	    else 
-                echo "$setting_key = $setting_var" >> /healthchecks/hc/local_settings.py
-	    fi
-        else
-            echo "$setting_key = \"$setting_var\"" >> /healthchecks/hc/local_settings.py
-        fi
+            echo "$setting_key = $setting_var" >> /healthchecks/hc/local_settings.py
+	fi
         echo "Added \"$setting_key\" (value \"$setting_var\") to local_settings.py"
     done
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,9 +94,9 @@ settingsConfiguration() {
                 echo "$setting_key = $setting_var" >> /healthchecks/hc/local_settings.py
 	    fi
         else
-            echo "$setting_key = \"$setting_var\"" >> /healthchecks/hc/settings.py
+            echo "$setting_key = \"$setting_var\"" >> /healthchecks/hc/local_settings.py
         fi
-        echo "Added \"$setting_key\" (value \"$setting_var\") to settings.py"
+        echo "Added \"$setting_key\" (value \"$setting_var\") to local_settings.py"
     done
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,7 +85,9 @@ settingsConfiguration() {
 
         if [ "$setting_type" = "plain" ]; then
             echo "$setting_key = $setting_var" >> /healthchecks/hc/local_settings.py
-	fi
+        else
+            echo "$setting_key = \"$setting_var\"" >> /healthchecks/hc/local_settings.py
+        fi
         echo "Added \"$setting_key\" (value \"$setting_var\") to local_settings.py"
     done
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,7 +84,15 @@ settingsConfiguration() {
         fi
 
         if [ "$setting_type" = "plain" ]; then
-            echo "$setting_key = $setting_var" >> /healthchecks/hc/settings.py
+            if [ "$setting_key" = "ALLOWED_HOSTS" ]; then
+	        if [ "$setting_var" = "*" ]; then
+			echo "ALLOWED_HOSTS = [\"*\"]" >> /healthchecks/hc/local_settings.py
+		else
+			echo "$setting_key = [\"$setting_var\"]" >> /healthchecks/hc/local_settings.py
+		fi
+	    else 
+                echo "$setting_key = $setting_var" >> /healthchecks/hc/local_settings.py
+	    fi
         else
             echo "$setting_key = \"$setting_var\"" >> /healthchecks/hc/settings.py
         fi


### PR DESCRIPTION
stumbled upon your docker image, didn't work using docker-compose at first.

Small changes:
- the default hc.sqlite ist located in /data not /healthchecks
- docker-compose creation failed because of ALLOWED_HOSTS 
- ENV added to local_settings.py instead of settings.py
- docker-compose example in Readme