### PR TITLE
feat: prune pings/notifications/flips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ HEALTHCHECK CMD wget --quiet --tries=1 --spider http://localhost:8000 || exit 1
 COPY entrypoint.sh /entrypoint.sh
 COPY includes/supervisor/ /etc/supervisor/
 COPY includes/nginx/ /etc/nginx/
+COPY includes/scripts/ /scripts/
 
 RUN chmod 755 /entrypoint.sh && \
     chown -R healthchecks:healthchecks \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ docker run \
     -e 'EMAIL_HOST_USER=user@example.com' \
     -e 'EMAIL_HOST_PASSWORD=YOUR_PASSWORD' \
     -e 'ALLOWED_HOSTS=localhost,*' \
+    -e 'CONTAINER_PRUNE_INTERVAL=600'
     galexrt/healthchecks:latest
 ```
 
@@ -98,6 +99,7 @@ The following environment variables can be used to configure some "special" valu
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ALLOWED_HOSTS` | Comma separated list of the allowed hosts, should be the hostnames the healthchecks container is reachable as for the Docker healthcheck to work, must include `localhost` |
 | `SECRET_KEY`    | Set to a random secret value (if unset or changed sessions are invalidated)                                                                                                |
+| `CONTAINER_PRUNE_INTERVAL`| Time in seconds between executions of `prunepings`, `prunenotifications` and `pruneflips`                                                                        |
 
 ### Other configuration variables
 
@@ -192,6 +194,7 @@ services:
       TWILIO_FROM: "None"
       PD_VENDOR_KEY: "None"
       TRELLO_APP_KEY: "None"
+      CONTAINER_PRUNE_INTERVAL: 600
 volumes:
   SQLite:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,5 +32,6 @@ services:
       TWILIO_FROM: "None"
       PD_VENDOR_KEY: "None"
       TRELLO_APP_KEY: "None"
+      CONTAINER_PRUNE_INTERVAL: 600
 volumes:
   SQLite:

--- a/includes/scripts/pruneflips.sh
+++ b/includes/scripts/pruneflips.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+while true; do
+    /usr/bin/python3 manage.py pruneflips
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        exit $ret
+    fi
+    sleep $1
+done

--- a/includes/scripts/prunenotifications.sh
+++ b/includes/scripts/prunenotifications.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+while true; do
+    /usr/bin/python3 manage.py prunenotifications
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        exit $ret
+    fi
+    sleep $1
+done

--- a/includes/scripts/prunepings.sh
+++ b/includes/scripts/prunepings.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+while true; do
+    /usr/bin/python3 manage.py prunepings
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        exit $ret
+    fi
+    sleep $1
+done

--- a/includes/supervisor/supervisord.conf
+++ b/includes/supervisor/supervisord.conf
@@ -56,3 +56,36 @@ stdout_logfile = /var/log/smtpd_out.log
 stdout_logfile_maxbytes = 10MB
 stderr_logfile = /var/log/smtpd_err.log
 stderr_logfile_maxbytes = 10MB
+
+[program:prunepings]
+command = /scripts/prunepings.sh %(ENV_CONTAINER_PRUNE_INTERVAL)s
+directory = /healthchecks
+user=healthchecks
+environment=HOME="/home/healthchecks",USER="healthchecks"
+autorestart = true
+stdout_logfile = /var/log/prunepings_out.log
+stdout_logfile_maxbytes = 10MB
+stderr_logfile = /var/log/prunepings_err.log
+stderr_logfile_maxbytes = 10MB
+
+[program:prunenotifications]
+command = /scripts/prunenotifications.sh %(ENV_CONTAINER_PRUNE_INTERVAL)s
+directory = /healthchecks
+user=healthchecks
+environment=HOME="/home/healthchecks",USER="healthchecks"
+autorestart = true
+stdout_logfile = /var/log/prunenotifications_out.log
+stdout_logfile_maxbytes = 10MB
+stderr_logfile = /var/log/prunenotifications_err.log
+stderr_logfile_maxbytes = 10MB
+
+[program:pruneflips]
+command = /scripts/pruneflips.sh %(ENV_CONTAINER_PRUNE_INTERVAL)s
+directory = /healthchecks
+user=healthchecks
+environment=HOME="/home/healthchecks",USER="healthchecks"
+autorestart = true
+stdout_logfile = /var/log/pruneflips_out.log
+stdout_logfile_maxbytes = 10MB
+stderr_logfile = /var/log/pruneflips_err.log
+stderr_logfile_maxbytes = 10MB


### PR DESCRIPTION
This PR adds supervisord configuration and utility scripts for pruning pings, notifications and flips.

The added environment variable `PRUNE_INTERVAL` is not part of the healthchecks project, should we add a prefix to make it distinguishable?