### PR TITLE
log all processes to stdout

### DIFF
--- a/includes/supervisor/supervisord.conf
+++ b/includes/supervisor/supervisord.conf
@@ -7,55 +7,51 @@ directory = /healthchecks
 user = healthchecks
 autorestart = true
 environment=HOME="/home/healthchecks",USER="healthchecks"
-stdout_events_enabled = true
-stderr_events_enabled = true
-stdout_logfile = /var/log/gunicorn_stdout.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/gunicorn_stderr.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:nginx]
 command = /usr/sbin/nginx -g 'daemon off;'
 autorestart = true
-stdout_events_enabled = true
-stderr_events_enabled = true
-stdout_logfile = /var/log/nginx_stdout.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/nginx_stderr.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:sendalerts]
-command = /usr/bin/python3 manage.py sendalerts
+command = /usr/bin/python3 -u manage.py sendalerts
 directory = /healthchecks
 user=healthchecks
 environment=HOME="/home/healthchecks",USER="healthchecks"
 autorestart = true
-stdout_logfile = /var/log/sendalerts_out.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/sendalerts_err.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:smtpd]
-command = /usr/bin/python3 manage.py smtpd --port 2525
+command = /usr/bin/python3 -u manage.py smtpd --port 2525
 directory = /healthchecks
 user=healthchecks
 environment=HOME="/home/healthchecks",USER="healthchecks"
 autorestart = true
-stdout_logfile = /var/log/smtpd_out.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/smtpd_err.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:sendreports]
-command = /usr/bin/python3 manage.py sendreports --loop
+command = /usr/bin/python3 -u manage.py sendreports --loop
 directory = /healthchecks
 user=healthchecks
 environment=HOME="/home/healthchecks",USER="healthchecks"
 autorestart = true
-stdout_logfile = /var/log/smtpd_out.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/smtpd_err.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:prunepings]
 command = /scripts/prunepings.sh %(ENV_CONTAINER_PRUNE_INTERVAL)s
@@ -63,10 +59,10 @@ directory = /healthchecks
 user=healthchecks
 environment=HOME="/home/healthchecks",USER="healthchecks"
 autorestart = true
-stdout_logfile = /var/log/prunepings_out.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/prunepings_err.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:prunenotifications]
 command = /scripts/prunenotifications.sh %(ENV_CONTAINER_PRUNE_INTERVAL)s
@@ -74,10 +70,10 @@ directory = /healthchecks
 user=healthchecks
 environment=HOME="/home/healthchecks",USER="healthchecks"
 autorestart = true
-stdout_logfile = /var/log/prunenotifications_out.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/prunenotifications_err.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:pruneflips]
 command = /scripts/pruneflips.sh %(ENV_CONTAINER_PRUNE_INTERVAL)s
@@ -85,10 +81,10 @@ directory = /healthchecks
 user=healthchecks
 environment=HOME="/home/healthchecks",USER="healthchecks"
 autorestart = true
-stdout_logfile = /var/log/pruneflips_out.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/pruneflips_err.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0
 
 [program:prunetokenbucket]
 command = /scripts/prunetokenbucket.sh %(ENV_CONTAINER_PRUNE_INTERVAL)s
@@ -96,7 +92,7 @@ directory = /healthchecks
 user=healthchecks
 environment=HOME="/home/healthchecks",USER="healthchecks"
 autorestart = true
-stdout_logfile = /var/log/prunetokenbucket_out.log
-stdout_logfile_maxbytes = 2MB
-stderr_logfile = /var/log/prunetokenbucket_err.log
-stderr_logfile_maxbytes = 2MB
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /dev/stderr
+stderr_logfile_maxbytes = 0


### PR DESCRIPTION
What do you think about redirecting all output to stdout?
Would make it easier to monitor logs directly via Docker.